### PR TITLE
Add hints to minibuffer

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -1605,7 +1605,7 @@ symbol `dape-connection'."
       ;; start server
       (when (plist-get config 'command)
         (let ((stderr-buffer
-               (generate-new-buffer "*dape-server stderr*"))
+               (get-buffer-create "*dape-server stderr*"))
               (command
                (cons (plist-get config 'command)
                      (cl-map 'list 'identity

--- a/dape.el
+++ b/dape.el
@@ -547,14 +547,18 @@ The hook is run with one argument, the compilation buffer."
   "List of watched expressions.")
 (defvar dape--connection nil
   "Debug adapter connection.")
-(defvar dape--mode-line-active nil
-  "If mode line is showing.")
 
 (defvar-local dape--source nil
   "Store source plist in fetched source buffer.")
 
 (defvar dape--repl-insert-text-guard nil
   "Guard var for *dape-repl* buffer text updates.")
+
+(define-minor-mode dape-active-mode
+  "On when dape debuggin session is active.
+Non interactive global minor mode."
+  :global t
+  :interactive nil)
 
 
 ;;; Utils
@@ -1578,8 +1582,9 @@ Killing the adapter and it's CONN."
              do (when (buffer-live-p buffer)
                   (kill-buffer buffer)))
     (setq dape--source-buffers nil
-          dape--repl-insert-text-guard nil
-          dape--mode-line-active t)
+          dape--repl-insert-text-guard nil)
+    (unless dape-active-mode
+      (dape-active-mode +1))
     (dape--update-state conn 'starting)
     (run-hook-with-args 'dape-update-ui-hooks conn))
   (dape--initialize conn))
@@ -1707,7 +1712,7 @@ symbol `dape-connection'."
                      ;; ui
                      (run-with-timer 1 nil (lambda ()
                                              (when (eq dape--connection conn)
-                                               (setq dape--mode-line-active nil)
+                                               (dape-active-mode -1)
                                                (force-mode-line-update t)))))
                    :request-dispatcher 'dape-handle-request
                    :notification-dispatcher 'dape-handle-event
@@ -3748,7 +3753,7 @@ See `eldoc-documentation-functions', for more infomation."
            'face 'font-lock-doc-face)))
 
 (add-to-list 'mode-line-misc-info
-             `(dape--mode-line-active
+             `(dape-active-mode
                (" [" (:eval (dape--mode-line-format)) "] ")))
 
 

--- a/dape.el
+++ b/dape.el
@@ -2051,7 +2051,7 @@ Using BUFFER and STR."
     (run-hook-with-args 'dape-compile-compile-hooks buffer)
     (dape dape--compile-config 'skip-compile))
    (t
-    (dape--repl-message (format "* Compilation failed %s *" str)))))
+    (dape--repl-message (format "* Compilation failed %s *" (string-trim-right str))))))
 
 (defun dape--compile (config)
   "Start compilation for CONFIG."


### PR DESCRIPTION
Inspired by joaotavora

Goals:
Try to minimize read commands in buffers. Using dape--read-config as much as possible.

- Change `dape-configs` to use functions to generate default values rather then read.
- Add hints in dape--read-config to be able to display default values with the extra benefit of adding some clarity for long strings.
- Add ensure errors in minibuffer.
- New symbol property dape--minibuffer-hint if function is safe to be evaluate in any context.
- lambdas are shown as *read* in hint
- changes in jdtls config to be default first instead of read 

<img width="973" alt="Screenshot 2024-01-12 at 15 06 38" src="https://github.com/svaante/dape/assets/1129021/65b81ff1-c984-40cf-91c3-b2713f0daa55">

With ensure error

<img width="973" alt="Screenshot 2024-01-12 at 15 08 41" src="https://github.com/svaante/dape/assets/1129021/fff04461-542a-446d-8e2e-f2c3608ac28d">
