### PR TITLE
Avoid relying on non-guaranteed return value of defun

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -4175,18 +4175,19 @@ See `eldoc-documentation-functions', for more infomation."
 
 ;;; Hooks
 
+(defun dape-kill-busy-wait ()
+  (let (done)
+    (dape-kill dape--connection
+               (dape--callback
+                (setq done t)))
+    ;; Busy wait for response at least 2 seconds
+    (cl-loop with max-iterations = 20
+             for i from 1 to max-iterations
+             until done
+             do (accept-process-output nil 0.1))))
+
 ;; Cleanup conn before bed time
-(add-hook 'kill-emacs-hook
-          (defun dape-kill-busy-wait ()
-            (let (done)
-              (dape-kill dape--connection
-                         (dape--callback
-                          (setq done t)))
-              ;; Busy wait for response at least 2 seconds
-              (cl-loop with max-iterations = 20
-                       for i from 1 to max-iterations
-                       until done
-                       do (accept-process-output nil 0.1)))))
+(add-hook 'kill-emacs-hook #'dape-kill-busy-wait)
 
 (provide 'dape)
 


### PR DESCRIPTION
According to its documentation, defun's return value is not defined.