### PR TITLE
Move setting dape-key-prefix to use-package ":preface", add gud pk

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,7 +37,7 @@ Currently =Dape= does not come with any debug adapter configuration.
 
 #+begin_src emacs-lisp
   (use-package dape
-    ;; By default dape uses gdb keybinding prefix
+    ;; By default dape shares the same keybinding prefix as `gud'
     ;; If you do not want to use any prefix, set it to nil.
     ;; :preface
     ;; (setq dape-key-prefix "\C-x\C-a")

--- a/README.org
+++ b/README.org
@@ -37,6 +37,14 @@ Currently =Dape= does not come with any debug adapter configuration.
 
 #+begin_src emacs-lisp
   (use-package dape
+    ;; By default dape uses gdb keybinding prefix
+    ;; If you do not want to use any prefix, set it to nil.
+    ;; :preface
+    ;; (setq dape-key-prefix "\C-x\C-a")
+    ;;
+    ;; May also need to set/change gud (gdb-mi) key prefix
+    ;; (setq gud-key-prefix "\C-x\C-a")
+
     ;; To use window configuration like gud (gdb-mi)
     ;; :init
     ;; (setq dape-buffer-window-arrangement 'gud)
@@ -52,10 +60,6 @@ Currently =Dape= does not come with any debug adapter configuration.
     ;; To display info and/or repl buffers on stopped
     ;; (add-hook 'dape-on-stopped-hooks 'dape-info)
     ;; (add-hook 'dape-on-stopped-hooks 'dape-repl)
-
-    ;; By default dape uses gdb keybinding prefix
-    ;; If you do not want to use any prefix, set it to nil.
-    ;; (setq dape-key-prefix "\C-x\C-a")
 
     ;; Kill compile buffer on build success
     ;; (add-hook 'dape-compile-compile-hooks 'kill-buffer)


### PR DESCRIPTION
Simple change to README.org.

* `dape-key-prefix` needs to be set prior to `use-package` `:config` and `:init` to work properly.
* Add in note about `gud-key-prefix` being set as well, since included by `dape` and may still overwrite other previously set `C-x C-a` prefixed commands.