### PR TITLE
Add "attach to already running Node process" js config

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -246,6 +246,12 @@
            :cwd dape-cwd
            :program dape-buffer-default
            :console "internalConsole")
+	  (js-debug-node-attach
+           modes (js-mode js-ts-mode typescript-mode typescript-ts-mode)
+           ,@js-debug
+           :type "pwa-node"
+	   :request "attach"
+	   :port 9229)
           (js-debug-chrome
            modes (js-mode js-ts-mode typescript-mode typescript-ts-mode)
            ,@js-debug


### PR DESCRIPTION
Pre-defined configurations existing before this commit are meant to *launch* a program and simultaneously debug it.

When I debug Node, I prefer to debug a little differently. I launch Node somewhere else (e.g. in a terminal emulator), like `node --inspect [program]` or `node --inspect-brk [program]`. Or even simpler: `node --inspect-brk -e "const x = 5; console.log(x);"`. I do it this way because the apps i launch are complex and running the `start the project` command launches multiple Node processes. So I just add --inspect to the ones I'd like to debug at the time, rather than trying to hack some crazy elaborate "run and inspect" setup.

Then I attach to the already running process using my preferred DAP client (dape, vscode, chrome devtools etc.)

In this case, you'd need to run M-x dape js-debug-node-attach

Because in Node `--inspect` by default starts debugging on port 9229, the default for the new debug configuration is also 9229.

However, if you prefer to use a different port, you can just do `M-x dape` and write `js-debug-node-attach :port 9030` in the minibuffer.