### PR TITLE
lldb-vscode is now called lldb-dap

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -258,6 +258,14 @@
            :type "pwa-chrome"
            :url "http://localhost:3000"
            :webRoot dape-cwd)))
+    (lldb-vscode
+     modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode)
+     ensure dape-ensure-command
+     command-cwd dape-command-cwd
+     command "lldb-vscode"
+     :type "lldb-vscode"
+     :cwd "."
+     :program "a.out")
     (lldb-dap
      modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode rustic-mode)
      ensure dape-ensure-command

--- a/dape.el
+++ b/dape.el
@@ -258,22 +258,20 @@
            :type "pwa-chrome"
            :url "http://localhost:3000"
            :webRoot dape-cwd)))
-    (lldb-vscode
-     modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode)
-     ensure dape-ensure-command
-     command-cwd dape-command-cwd
-     command "lldb-vscode"
-     :type "lldb-vscode"
-     :cwd "."
-     :program "a.out")
-    (lldb-dap
-     modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode rustic-mode)
-     ensure dape-ensure-command
-     command-cwd dape-command-cwd
-     command "lldb-dap"
-     :type "lldb-dap"
-     :cwd "."
-     :program "a.out")
+    ,@(let ((lldb-common
+             `(modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode rustic-mode)
+               ensure dape-ensure-command
+               command-cwd dape-command-cwd
+               :cwd "."
+               :program "a.out")))
+        `((lldb-vscode
+           command "lldb-vscode"
+           :type "lldb-vscode"
+           ,@lldb-common)
+          (lldb-dap
+           command "lldb-dap"
+           :type "lldb-dap"
+           ,@lldb-common)))
     (netcoredbg
      modes (csharp-mode csharp-ts-mode)
      ensure dape-ensure-command

--- a/dape.el
+++ b/dape.el
@@ -258,12 +258,12 @@
            :type "pwa-chrome"
            :url "http://localhost:3000"
            :webRoot dape-cwd)))
-    (lldb-vscode
-     modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode)
+    (lldb-dap
+     modes (c-mode c-ts-mode c++-mode c++-ts-mode rust-mode rust-ts-mode rustic-mode)
      ensure dape-ensure-command
      command-cwd dape-command-cwd
-     command "lldb-vscode"
-     :type "lldb-vscode"
+     command "lldb-dap"
+     :type "lldb-dap"
      :cwd "."
      :program "a.out")
     (netcoredbg


### PR DESCRIPTION
Since October 2019
https://discourse.llvm.org/t/rfc-rename-lldb-vscode-to-lldb-dap/74075
https://lldb.llvm.org/resources/lldbdap.html

Also adds support for [rustic-mode](https://github.com/brotzeit/rustic)