### PR TITLE
Fix dape--repl-message showing messages

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -4311,8 +4311,7 @@ Handles newline."
     (setq msg (concat "\n" msg))
     (if (not (get-buffer-window "*dape-repl*"))
         (when (stringp msg)
-          (message "%s" (format "%s" (string-trim msg))
-                   'face face))
+          (message "%s" (propertize (format "%s" (string-trim msg)) 'face face)))
       (cond
        (dape--repl-insert-text-guard
         (run-with-timer 0.1 nil 'dape--repl-message msg))

--- a/dape.el
+++ b/dape.el
@@ -4311,7 +4311,7 @@ Handles newline."
     (setq msg (concat "\n" msg))
     (if (not (get-buffer-window "*dape-repl*"))
         (when (stringp msg)
-          (message (format "%s" (string-trim msg))
+          (message "%s" (format "%s" (string-trim msg))
                    'face face))
       (cond
        (dape--repl-insert-text-guard


### PR DESCRIPTION
This PR fixes 2 bugs with `dape--repl-message` when it calls
`message`.