### PR TITLE
Don't show "Unknown mime type nil, see `dape-mime-mode-alist`"

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -3119,12 +3119,13 @@ See `dape-request' for expected CB signature."
                   (plist-put dape--source-buffers
                              (plist-get source :sourceReference) buffer))
             (with-current-buffer buffer
-              (if-let ((mode
-                        (alist-get mimeType dape-mime-mode-alist nil nil 'equal)))
-                  (unless (eq major-mode mode)
-                    (funcall mode))
-                (message "Unknown mime type %s, see `dape-mime-mode-alist'"
-                         mimeType))
+              (when mimeType
+                (if-let ((mode
+                          (alist-get mimeType dape-mime-mode-alist nil nil 'equal)))
+                    (unless (eq major-mode mode)
+                      (funcall mode))
+                  (message "Unknown mime type %s, see `dape-mime-mode-alist'"
+                           mimeType)))
               (setq-local buffer-read-only t
                           dape--source source)
               (let ((inhibit-read-only t))


### PR DESCRIPTION
There is nothing the user can do if the mimetype is nil.