### PR TITLE
Add `command-env` symbol key to `dape-configs`

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -515,7 +515,7 @@ Functions and symbols:
                         ((const :tag "Host of debug adapter" host) string)
                         ((const :tag "Port of debug adapter" port) natnum)
                         ((const :tag "Compile cmd" compile) string)
-                        ((const :tag "Use configurationDone as trigger for launch/attach" defer-launch-attach) :type 'boolean)
+                        ((const :tag "Use configurationDone as trigger for launch/attach" defer-launch-attach) boolean)
                         ((const :tag "Adapter type" :type) string)
                         ((const :tag "Request type launch/attach" :request) string)))))
 


### PR DESCRIPTION
Hi @svaante 👋 

I started using dape for my Ruby development lately, and it's a blast! Thanks so much for all your work on this 💛 

The Ruby debugging facilities support configuration by an [extensive list of environment variables](https://github.com/ruby/debug/tree/master?tab=readme-ov-file#configuration-list), which comes in handy for setting up dape configurations -- specifically if you don't (or can't) rely on `rdbg -c ...` to invoke the command to debug.

To make it a little easier to create a custom environment for `command`, this MR introduces new symbol key `command-env` to `dape-configs`.

Here's an example use to illustrate:

```lisp
(add-to-list 'dape-configs
             '(rails-test-at-point
               modes (ruby-mode ruby-ts-mode)
               ensure dape-ensure-command
               command "rails"
               command-args ("test" :location)
               command-env ("RUBY_DEBUG_PORT" 12345)
               command-cwd dape-command-cwd
               fn (lambda (config)
                    (plist-put config 'command-args
                               (mapcar
                                (lambda (arg)
                                  (if (eq arg :location) (plist-get config 'location) arg))
                                (plist-get config 'command-args))))
               location (lambda ()
                    (format "%s:%d" (dape-buffer-default) (line-number-at-pos nil t)))
               port 12345))
```

The changeset in this MR is a proof-of-concept only for now. I wanted to run this by you for feedback before I put more time into it. If you like the idea, I'm happy to polish the MR some more:

- add documentation where needed, and
- run `command-env` through `dape-default-config-functions` and `fn`, same as `command-args`.

Let me know what you think!
Thanks!