### PR TITLE
Fix misplaced parens in define-key call.

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -3615,8 +3615,8 @@ displayed."
   (run-hooks 'dape-update-ui-hook))
 
 (dape--buffer-map dape-info-data-breakpoints-line-map nil
-  (define-key map "D" 'dape-info-data-breakpoint-delete
-  (define-key map "d" 'dape-info-data-breakpoint-delete)))
+  (define-key map "D" 'dape-info-data-breakpoint-delete)
+  (define-key map "d" 'dape-info-data-breakpoint-delete))
 
 (dape--command-at-line dape-info-exceptions-toggle (dape--info-exception)
   "Toggle exception at line in dape info buffer."


### PR DESCRIPTION
On newer versions of Emacs, the old code will not error out immediately and will work by accident, though it's definitely wrong. On Emacs 28, it will give an error because define-key is called with the wrong number of arguments.