### PR TITLE
Get a substring from the minibuffer prompt without text properties.

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -4885,7 +4885,8 @@ Update `dape--inlay-hint-overlays' from SCOPES."
   "Display current configuration in minibuffer in overlay."
   (pcase-let*
       ((`(,key ,config ,error-message ,hint-rows) dape--minibuffer-cache)
-       (str (string-trim (buffer-substring (minibuffer-prompt-end) (point-max))))
+       (str (string-trim
+             (buffer-substring-no-properties (minibuffer-prompt-end) (point-max))))
        (`(,hint-key ,hint-config) (ignore-errors (dape--config-from-string str)))
        (default-directory
         (or (with-current-buffer dape--minibuffer-last-buffer


### PR DESCRIPTION
Hi!

The minibuffer prompt may have text properties depending on the Emacs modes enabled. So, let us clean up a substring copied from it.

Best regards,
Vladimir.