### PR TITLE
Mention eglot-workspace-configuration for jdtls configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -158,13 +158,21 @@ See https://github.com/ruby/debug for more information
 See https://github.com/eclipse-jdtls/eclipse.jdt.ls for installation of JDTLS.
 See https://github.com/microsoft/java-debug for installation of the Java Debug Server plugin.
 The Java config depends on Eglot running JDTLS with the plugin prior to starting Dape.
-Extend ~eglot-server-programs~ as follows to have JDTLS load the plugin:
+Either globally extend ~eglot-server-programs~ as follows to have JDTLS always load the plugin:
 #+begin_src emacs-lisp
   (add-to-list 'eglot-server-programs
-               `((java-mode java-ts-mode) .
+               '((java-mode java-ts-mode) .
                  ("jdtls"
                   :initializationOptions
                   (:bundles ["/PATH/TO/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-VERSION.jar"]))))
+#+end_src
+
+Alternatively, set the variable ~eglot-workspace-configuration~ in the file =.dir-locals.el= in a project's root directory, to have JDTLS load the plugin for that project:
+#+begin_src emacs-lisp
+;; content of /project/.dir-locals.el
+((nil . ((eglot-workspace-configuration
+          . (:jdtls (:initializationOptions
+                     (:bundles ["/PATH/TO/java-debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-VERSION.jar"])))))))
 #+end_src
 
 ** PHP - Xdebug


### PR DESCRIPTION
`eglot-workspace-configuration` can be used to add per-server initialization options without modifying the global `eglot-server-list` variable.  It only works as a per-project setting but might still be useful in the documentation.

Feel free to drop the pull request if you feel it's an unnecessary detail!