### PR TITLE
Support for debugging go with gdb

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -203,26 +203,6 @@
      :type "go"
      :cwd "."
      :program ".")
-    (go-gdb-test
-     modes (go-mode go-ts-mode)
-     command "gdb"
-     command-args ("--interpreter=dap")
-     command-cwd (lambda () (file-name-directory (buffer-file-name)))
-     compile (lambda () (format "go test -c -o %s -gcflags '-N -l'" (dape--go-test-binary-name))) ;; compile without optimizations
-     :request "launch"
-     :program dape--go-test-binary-name
-     :args []
-     :stopAtBeginningOfMainSubprogram t)
-    (go-gdb
-     modes (go-mode go-ts-mode)
-     command "gdb"
-     command-args ("--interpreter=dap")
-     command-cwd dape-command-cwd
-     compile (lambda () (format "go build -o %s -gcflags '-N -l'" (dape--go-binary-name))) ;; compile without optimizations
-     :request "launch"
-     :program dape--go-binary-name
-     :args []
-     :stopAtBeginningOfMainSubprogram t)
     (flutter
      ensure dape-ensure-command
      modes (dart-mode)
@@ -254,6 +234,38 @@
      :program "a.out"
      :args []
      :stopAtBeginningOfMainSubprogram nil)
+    ,@(let ((gdb-common
+	     `( ensure (lambda (config)
+			 (dape-ensure-command config)
+			 (let* ((default-directory
+				 (or (dape-config-get config 'command-cwd)
+				     default-directory))
+				(command (dape-config-get config 'command))
+				(output (shell-command-to-string (format "%s --version" command)))
+				(version (save-match-data
+					   (when (string-match "GNU gdb \\(?:(.*) \\)?\\([0-9.]+\\)" output)
+					     (string-to-number (match-string 1 output))))))
+			   (unless (>= version 14.1)
+			     (user-error "Requires gdb version >= 14.1"))))
+		command "gdb"
+		command-args ("--interpreter=dap")
+		:request "launch"
+		:stopAtBeginningOfMainSubprogram nil)))
+	     `((go-gdb-test ,@gdb-common
+			    modes (go-mode go-ts-mode)
+			    command-cwd (file-name-directory (buffer-file-name))
+			    compile (format "go test -c -o %s -gcflags='all=-N -l'"
+					    (expand-file-name "__test.bin" temporary-file-directory)) ;; compile without optimizations
+			    :program (expand-file-name "__test.bin" temporary-file-directory)
+			    :args [])
+	       (go-gdb ,@gdb-common
+		       modes (go-mode go-ts-mode)
+		       command-cwd (file-name-directory (buffer-file-name))
+		       compile (format "go build -o %s -gcflags='all=-N -l'"
+				       (expand-file-name "__binary.bin" temporary-file-directory)) ;; compile without optimizations
+		       :request "launch"
+		       :program (expand-file-name "__binary.bin" temporary-file-directory)
+		       :args [])))
     (godot
      modes (gdscript-mode)
      port 6006
@@ -445,8 +457,8 @@
                                        "out"
                                        "phpDebug.js")))
      :type "php"
-     :port 9003))
-  "This variable holds the dape configurations as an alist.
+     :port 9003)
+    "This variable holds the dape configurations as an alist.
 In this alist, the car element serves as a symbol identifying each
 configuration.  Each configuration, in turn, is a property list (plist)
 where keys can be symbols or keywords.
@@ -499,7 +511,7 @@ Keywords in configuration:
 Functions and symbols:
   - If a value is a function, its return value replaces the key's
     value before execution.  The function is called with no arguments.
-  - If a value is a symbol, it resolves recursively before execution."
+  - If a value is a symbol, it resolves recursively before execution.")
   :type '(alist :key-type (symbol :tag "Name")
                 :value-type
                 (plist :options

--- a/dape.el
+++ b/dape.el
@@ -57,7 +57,6 @@
 (require 'hexl)
 (require 'tramp)
 (require 'jsonrpc)
-(require 'which-func)
 
 
 ;;; Custom
@@ -457,8 +456,8 @@
                                        "out"
                                        "phpDebug.js")))
      :type "php"
-     :port 9003)
-    "This variable holds the dape configurations as an alist.
+     :port 9003))
+  "This variable holds the dape configurations as an alist.
 In this alist, the car element serves as a symbol identifying each
 configuration.  Each configuration, in turn, is a property list (plist)
 where keys can be symbols or keywords.
@@ -511,7 +510,7 @@ Keywords in configuration:
 Functions and symbols:
   - If a value is a function, its return value replaces the key's
     value before execution.  The function is called with no arguments.
-  - If a value is a symbol, it resolves recursively before execution.")
+  - If a value is a symbol, it resolves recursively before execution."
   :type '(alist :key-type (symbol :tag "Name")
                 :value-type
                 (plist :options

--- a/dape.el
+++ b/dape.el
@@ -900,22 +900,6 @@ Non interactive global minor mode."
 
 ;;; Utils
 
-(defun dape--go-test-name ()
-  "Retrieve Go test function name from current cursor position."
-  (if-let* ((file-name (buffer-file-name))
-            ((string-suffix-p "_test.go" file-name))
-            (fn-name (which-function)))
-      `["-test.run" ,(concat "^" (car (split-string (substring-no-properties fn-name))) "$")]
-    []))
-
-(defun dape--go-test-binary-name ()
-  "Format path to Go debugged test binary executable file."
-  (concat (temporary-file-directory) "__test.bin"))
-
-(defun dape--go-binary-name ()
-  "Format path to Go debugger binary exectuable file."
-  (concat (temporary-file-directory) "__prog.bin"))
-
 (defun dape--warn (format &rest args)
   "Display warning/error message with FORMAT and ARGS."
   (dape--repl-insert-error (format "* %s *\n" (apply #'format format args))))


### PR DESCRIPTION
This PR introduces configuration to debug
Go applications with GDB, since Delve is not
supported on OpenBSD.

https://github.com/svaante/dape/issues/94

At this moment, this PR has been tested on Fedora 40 with GDB 15.2.

For reasons unknown, the debugger fails to hit the breakpoint unless
`:stopAtBeginningOfMainSubprogram` is set to `t`.

It used to work with older version of `dape`, so could it be some sort of regression perhaps?

Debugging test using `go-gdb-test` target doesn't work because it can't stop at beginning of `main`.

`go-gdb` target works.

@svaante I'll probably need some assistance as I'm not familiar enough with DAP to land this.