### PR TITLE
Skip checking breakpoint file when the file doesn't exist

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -3267,10 +3267,11 @@ Will use `dape-default-breakpoints-file' if FILE is nil."
              into serialized finally do
              (prin1 serialized (current-buffer)))
     ;; Skip write if nothing has changed since last save
-    (unless (equal (buffer-string)
+    (unless (and (file-exists-p file)
+                 (equal (buffer-string)
                    (with-temp-buffer
                      (insert-file-contents file)
-                     (buffer-string)))
+                     (buffer-string))))
       (write-region (point-min) (point-max) file nil
                     (unless (called-interactively-p 'interactive) 'quiet)))))
 


### PR DESCRIPTION
When `dape-breakpoint-save` is called, it currently attempts to read the breakpoint file via `insert-file-contents` without first verifying the file's existence. For first-time users, this generates an error message since the file hasn't been created yet. The error persists on every Emacs exit until the user manually creates the file. This patch adds a simple existence check before attempting to read the file.