### PR TITLE
Align dlv type field with DAP conventions

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -200,7 +200,7 @@
      command-insert-stderr t
      port :autoport
      :request "launch"
-     :type "debug"
+     :type "go"
      :cwd "."
      :program ".")
     (flutter


### PR DESCRIPTION
## Description

This PR updates the `dlv` (Delve) adapter's `:type` field from `"debug"` to `"go"` to align with standard DAP conventions.

## Rationale

- The VS Code Go extension uses `"type": "go"` in its launch configurations ([source](https://github.com/golang/vscode-go/blob/master/extension/package.json#L554))
- Other adapters in `dape` follow a similar pattern using their language/tool name:
    - `debugpy` uses `"python"`
    - `java-debug` uses `"java"`
    - etc.

## Impact

This change is cosmetic and doesn't affect functionality - it simply brings the `dlv` configuration in line with established conventions for better consistency across the codebase.

  ---

  Thanks for maintaining `dape` @svaante! It's been a great tool for debugging in Emacs. 🙏