### PR TITLE
feat: add new TypeScript mode using tsx over ts-node

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -271,6 +271,14 @@
            :cwd dape-cwd
            :program dape-buffer-default
            :console "internalConsole")
+          (js-debug-tsx
+           modes (typescript-mode typescript-ts-mode)
+           ,@js-debug
+           :type "pwa-node"
+           :runtimeExecutable "tsx"
+           :cwd dape-cwd
+           :program dape-buffer-default
+           :console "internalConsole")
 	  (js-debug-node-attach
            modes (js-mode js-ts-mode typescript-mode typescript-ts-mode)
            ,@js-debug


### PR DESCRIPTION
This PR adds a new debugging mode for TypeScript that runs `tsx` over `ts-node`. AFAIK, `ts-node` is abandoned (the latest commit was 2 yrs ago).