### PR TITLE
Fix dape-memory buffer creation

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -2817,7 +2817,7 @@ Using BUFFER and STR."
                 (delete-region (match-beginning 0) (match-end 0))
                 ;; `hexl' does not support address over 8 hex chars
                 (insert (append (substring address (- (length address) 8)))))))
-          (replace-region-contents (point-min) (point-max) temp-buffer)
+          (replace-region-contents (point-min) (point-max) (lambda () temp-buffer))
           (when buffer-empty-p (hexl-goto-address 0))
           (kill-buffer temp-buffer))
         (set-buffer-modified-p nil)


### PR DESCRIPTION
Running `dape-memory` command while debugging a C project results in the following error:

```
Error running timer: (invalid-function #<buffer  *temp*-18550>)
```

I've traced the issue to the `dape--memory-revert` function which seems to misuse the `replace-region-contents` function by passing in the buffer directly instead of a function returning a buffer (or a string) as instructed by the docs:

```
(replace-region-contents BEG END REPLACE-FN &optional MAX-SECS MAX-COSTS)
...
Replace the region between BEG and END using REPLACE-FN.

REPLACE-FN runs on the current buffer narrowed to the region.  It
should return either a string or a buffer replacing the region.
```

The bug seems to have been introduced recently in: 73844a8 Fix new obsolete warnings in emacs 31.3

