### PR TITLE
Fix silent failure on expanding variable

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -4728,7 +4728,8 @@ The search is done backwards from POINT.  The line is marked with
 
 (defun dape--repl-revert-region (&rest _)
   "Revert region by cont text property dape--revert-tag."
-  (when-let* ((fn (get-text-property (point) 'dape--revert-fn))
+  (when-let* ((inhibit-read-only t)
+			  (fn (get-text-property (point) 'dape--revert-fn))
               (start (save-excursion
                        (previous-single-property-change
                         (1+ (point)) 'dape--revert-tag)))


### PR DESCRIPTION
Fixes svaante/dape#281, see for full details

When using dape with Doom Emacs, expanding variables in the `*dape-repl*` buffer causes the variable output to disappear instead of expanding. The content is deleted but not re-inserted.

This is because the content re-insertion silently fails if the REPL buffer content has `field` text properties.