### PR TITLE
Add support for haskell-debugger

### DIFF
--- a/dape.el
+++ b/dape.el
@@ -428,7 +428,21 @@
                                        "out"
                                        "phpDebug.js")))
      :type "php"
-     :port 9003))
+     :port 9003)
+    (hdb
+     modes (haskell-mode haskell-ts-mode haskell-literate-mode)
+     ensure dape-ensure-command
+     command "hdb"
+     command-cwd dape-command-cwd
+     command-args ("server" "-v0" "--port" :autoport)
+     host "localhost"
+     port :autoport
+     :type "haskell"
+     :request "launch"
+     :entryFile (buffer-file-name)
+     :projectRoot dape-command-cwd
+     :entryArgs []
+     :extraGhcArgs []))
   "This variable holds the dape configurations as an alist.
 In this alist, the car element serves as a symbol identifying each
 configuration.  Each configuration, in turn, is a property list (plist)


### PR DESCRIPTION
[Haskell-debugger](https://well-typed.github.io/haskell-debugger/) is a new debugger for Haskell. I feel it might be a good idea to upstream this change so more Haskellers can enjoy it without configuring anything.

(Related to https://github.com/well-typed/haskell-debugger/issues/213 )

I've done FSF copyright assignment.